### PR TITLE
Sending the JWT to engine when prepping the session.

### DIFF
--- a/src/DocPrepper.js
+++ b/src/DocPrepper.js
@@ -10,7 +10,7 @@ const logger = require('./Logger').get();
 // the last socket to a session:
 const DEFAULT_TTL = 5;
 
-function createConfiguration(host, port, sessionId) {
+function createConfiguration(host, port, sessionId, jwt) {
   const config = {
     schema: qixSchema,
     session: {
@@ -24,7 +24,8 @@ function createConfiguration(host, port, sessionId) {
     createSocket(url) {
       return new WebSocket(url, {
         headers: {
-          'X-Qlik-Session': sessionId
+          'X-Qlik-Session': sessionId,
+          Authorization: jwt
         }
       });
     },
@@ -34,9 +35,9 @@ function createConfiguration(host, port, sessionId) {
 }
 
 class DocPrepper {
-  static async prepareDoc(host, port, docId) {
+  static async prepareDoc(host, port, docId, jwt) {
     const sessionId = uuid();
-    const config = createConfiguration(host, port, sessionId);
+    const config = createConfiguration(host, port, sessionId, jwt);
     try {
       const qix = await enigma.getService('qix', config);
       const doc = docId ? await qix.global.openDoc(docId) : await qix.global.createSessionApp();

--- a/src/QixSessionService.js
+++ b/src/QixSessionService.js
@@ -12,13 +12,11 @@ class QixSessionService {
    * @param docId
    * @returns {Promise<TResult>}
    */
-  static async openSession(docId) {
+  static async openSession(docId, jwt) {
     // Get list of possible engines
     const engines = await engineDiscoveryClient.queryEngines(healthyQuery);
-
     // Select one of them and get the address.
     const engine = engineLoadBalancer.roundRobin(engines);
-
     if (!engine) {
       logger.error('Engine load balancer did not return an engine');
       throw createError(503, 'No suitable QIX Engine available');
@@ -28,7 +26,7 @@ class QixSessionService {
 
     try {
       // Prepare the session
-      const sessionId = await engineSessionPrepper.prepareDoc(ipAddress, port, docId);
+      const sessionId = await engineSessionPrepper.prepareDoc(ipAddress, port, docId, jwt);
       const sessionInfo = { ipAddress, port, sessionId };
       if (docId.length !== 0) { sessionInfo.docId = docId; }
       logger.info('Session opened', sessionInfo);

--- a/src/index.js
+++ b/src/index.js
@@ -41,12 +41,12 @@ router.get(`/${healthEndpoint}`, async (ctx) => { ctx.body = 'OK'; });
 
 router.get(`/${sessionEndpoint}/doc/:docId`, async (ctx) => {
   const fullDocId = `/doc/${ctx.params.docId}`;
-  const sessionInfo = await qixSessionService.openSession(fullDocId);
+  const sessionInfo = await qixSessionService.openSession(fullDocId, ctx.headers.authorization);
   ctx.body = JSON.stringify(sessionInfo, undefined, '   ');
 });
 
 router.get(`/${sessionEndpoint}/session-doc`, async (ctx) => {
-  const sessionInfo = await qixSessionService.openSession('');
+  const sessionInfo = await qixSessionService.openSession('', ctx.headers.authorization);
   ctx.body = JSON.stringify(sessionInfo, undefined, '   ');
 });
 


### PR DESCRIPTION
Now sending the JWT to the engine when prepping the session.

We do not need to send it to mira since mira only talks to engine on the /health path which is not JWT protected.