### PR TITLE
Initialize session metrics on startup of service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: qlikcore/qix-session-placement-service${TAG} # If TAG is not set docker image with tag 'latest' will be used.
     ports:
       - "9455:9455"
+    environment:
+      - SESSIONS_PER_ENGINE_THRESHOLD=100
 
   mira:
     image: qlikcore/mira:0.3.1

--- a/src/QixSessionService.js
+++ b/src/QixSessionService.js
@@ -6,6 +6,18 @@ const logger = require('./Logger').get();
 
 class QixSessionService {
   /**
+   * Method for initializing metrics for active and remaining sessions
+   */
+  static async init() {
+    try {
+      const engines = await engineDiscoveryClient.listEngines();
+      engineLoadBalancer.checkMaxSessions(engines);
+    } catch (err) {
+      logger.error(`Engine Discovery client did not return any engine instances when initializing metrics ${err}`);
+    }
+  }
+
+  /**
    * Picks an engine
    * @param docId
    * @returns {Promise<TResult>}

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,11 @@ app
   .use(router.routes())
   .use(router.allowedMethods());
 
+// Initialize metrics for active and remaining sessions
+setTimeout(() => {
+  qixSessionService.init();
+}, 10000);
+
 server = app.listen(Config.port);
 
 logger.info(`Listening on port ${Config.port}`);


### PR DESCRIPTION
Earlier the metrics for `activeSessions` and `remainingSessions` were not set before the first session was opened. With this commit the metrics will be set 10 seconds after startup of the service. The 10 seconds delay is due to that the metrics are reliant on `mira` being up and running and being able to discover engines.

If `mira` is not responding or if no engines are running both metrics will be `0`.

This closes #45  