### PR TITLE
Skip setting timestamp on gauges

### DIFF
--- a/src/LoadBalancer.js
+++ b/src/LoadBalancer.js
@@ -128,14 +128,13 @@ class LoadBalancer {
       return true;
     });
 
-    const timestamp = Date.now();
     // Record total active sessions on all nodes
-    activeSessionsTotalGauge.set(totalSessions, timestamp);
+    activeSessionsTotalGauge.set(totalSessions);
 
     // Record number of remaining sessions before threshold is reached. Could be negative.
     if (Config.sessionsPerEngineThreshold) {
       const nbrTotalAllowedSessions = engines.length * Config.sessionsPerEngineThreshold;
-      remainingSessionsGauge.set(nbrTotalAllowedSessions - totalSessions, timestamp);
+      remainingSessionsGauge.set(nbrTotalAllowedSessions - totalSessions);
     }
 
     return filteredEngines;


### PR DESCRIPTION
In core-scaling we are seeing prometheus logging errors due to the timestamps that we set on our gauges. Since a timestamp is not needed on a gauge, lets remove them. I have verified that Prometheus no longer logs any errors if they are removed.